### PR TITLE
genval generates only exported method

### DIFF
--- a/examples/complicated/validators.go
+++ b/examples/complicated/validators.go
@@ -10,66 +10,50 @@ import (
 	"unicode/utf8"
 )
 
-type Validatable interface {
+type validatable interface {
 	Validate() error
 }
 
-func callValidateIfValidatable(i interface{}) error {
-	if v, ok := i.(Validatable); ok {
-		if err := v.Validate(); err != nil {
-			return err
-		}
+func validate(i interface{}) error {
+	if v, ok := i.(validatable); ok {
+		return v.Validate()
 	}
 	return nil
 }
 
-func (r AliasArray) validate() error {
+// Validate validates AliasArray
+func (r AliasArray) Validate() error {
 	for _, x := range r {
 		_ = x
 	}
 	return nil
 }
 
-func (r AliasArray) Validate() error {
-	return r.validate()
-}
-
-func (r AliasChan) validate() error {
-	return nil
-}
-
+// Validate validates AliasChan
 func (r AliasChan) Validate() error {
-	return r.validate()
-}
-
-func (r AliasFunc) validate() error {
 	return nil
 }
 
+// Validate validates AliasFunc
 func (r AliasFunc) Validate() error {
-	return r.validate()
+	return nil
 }
 
-func (r AliasOnDogsMapAlias) validate() error {
+// Validate validates AliasOnDogsMapAlias
+func (r AliasOnDogsMapAlias) Validate() error {
 	if err := DogsMapAlias(r).Validate(); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (r AliasOnDogsMapAlias) Validate() error {
-	return r.validate()
-}
-
-func (r AliasString) validate() error {
+// Validate validates AliasString
+func (r AliasString) Validate() error {
 	return nil
 }
 
-func (r AliasString) Validate() error {
-	return r.validate()
-}
-
-func (r Dog) validate() error {
+// Validate validates Dog
+func (r Dog) Validate() error {
 	if utf8.RuneCountInString(r.Name) < 1 {
 		return fmt.Errorf("field Name is shorter than 1 chars")
 	}
@@ -79,11 +63,8 @@ func (r Dog) validate() error {
 	return nil
 }
 
-func (r Dog) Validate() error {
-	return r.validate()
-}
-
-func (r DogsMapAlias) validate() error {
+// Validate validates DogsMapAlias
+func (r DogsMapAlias) Validate() error {
 	for k, v := range r {
 		_ = k
 		_ = v
@@ -94,21 +75,8 @@ func (r DogsMapAlias) validate() error {
 	return nil
 }
 
-func (r DogsMapAlias) Validate() error {
-	return r.validate()
-}
-
-func (r State) validate() error {
-	switch r {
-	case StateOk:
-	case StateError:
-	default:
-		return fmt.Errorf("invalid value for enum State: %v", r)
-	}
-	return nil
-}
-
-func (r Status) validate() error {
+// Validate validates Status
+func (r Status) Validate() error {
 	switch r {
 	case StatusCreated:
 	case StatusPending:
@@ -120,11 +88,8 @@ func (r Status) validate() error {
 	return nil
 }
 
-func (r Status) Validate() error {
-	return r.validate()
-}
-
-func (r User) validate() error {
+// Validate validates User
+func (r User) Validate() error {
 	if utf8.RuneCountInString(r.Name) < 3 {
 		return fmt.Errorf("field Name is shorter than 3 chars")
 	}
@@ -264,8 +229,4 @@ func (r User) validate() error {
 		}
 	}
 	return nil
-}
-
-func (r User) Validate() error {
-	return r.validate()
 }

--- a/examples/overriding/ex5_additional.go
+++ b/examples/overriding/ex5_additional.go
@@ -12,9 +12,10 @@ type Age5 struct {
 	Value int `validate:"min=3,max=64"`
 }
 
-func (r Request5) Validate() error {
+func (r Request5) validate() error {
 	if r.Age.Value == 10 && r.Some == 10 {
 		return fmt.Errorf("fields Age and Some can't be 10 at the same time")
 	}
-	return r.validate()
+
+	return nil
 }

--- a/examples/overriding/validators.go
+++ b/examples/overriding/validators.go
@@ -8,34 +8,19 @@ import (
 	"fmt"
 )
 
-type Validatable interface {
+type validatable interface {
 	Validate() error
 }
 
-func callValidateIfValidatable(i interface{}) error {
-	if v, ok := i.(Validatable); ok {
-		if err := v.Validate(); err != nil {
-			return err
-		}
+func validate(i interface{}) error {
+	if v, ok := i.(validatable); ok {
+		return v.Validate()
 	}
 	return nil
 }
 
-func (r Age1) validate() error {
-	if r.Value < 3 {
-		return fmt.Errorf("field Value is less than 3 ")
-	}
-	if r.Value > 64 {
-		return fmt.Errorf("field Value is more than 64 ")
-	}
-	return nil
-}
-
+// Validate validates Age1
 func (r Age1) Validate() error {
-	return r.validate()
-}
-
-func (r Age2) validate() error {
 	if r.Value < 3 {
 		return fmt.Errorf("field Value is less than 3 ")
 	}
@@ -45,11 +30,8 @@ func (r Age2) validate() error {
 	return nil
 }
 
+// Validate validates Age2
 func (r Age2) Validate() error {
-	return r.validate()
-}
-
-func (r Age3) validate() error {
 	if r.Value < 3 {
 		return fmt.Errorf("field Value is less than 3 ")
 	}
@@ -59,11 +41,8 @@ func (r Age3) validate() error {
 	return nil
 }
 
+// Validate validates Age3
 func (r Age3) Validate() error {
-	return r.validate()
-}
-
-func (r Age4) validate() error {
 	if r.Value < 3 {
 		return fmt.Errorf("field Value is less than 3 ")
 	}
@@ -73,11 +52,8 @@ func (r Age4) validate() error {
 	return nil
 }
 
+// Validate validates Age4
 func (r Age4) Validate() error {
-	return r.validate()
-}
-
-func (r Age5) validate() error {
 	if r.Value < 3 {
 		return fmt.Errorf("field Value is less than 3 ")
 	}
@@ -87,24 +63,19 @@ func (r Age5) validate() error {
 	return nil
 }
 
+// Validate validates Age5
 func (r Age5) Validate() error {
-	return r.validate()
-}
-
-func (r Request1) validate() error {
-	if err := r.Age.Validate(); err != nil {
-		return err
+	if r.Value < 3 {
+		return fmt.Errorf("field Value is less than 3 ")
 	}
-	if r.Some < 3 {
-		return fmt.Errorf("field Some is less than 3 ")
-	}
-	if r.Some > 64 {
-		return fmt.Errorf("field Some is more than 64 ")
+	if r.Value > 64 {
+		return fmt.Errorf("field Value is more than 64 ")
 	}
 	return nil
 }
 
-func (r Request2) validate() error {
+// Validate validates Request2
+func (r Request2) Validate() error {
 	if err := r.Age.ValidateMin10(); err != nil {
 		return err
 	}
@@ -117,11 +88,8 @@ func (r Request2) validate() error {
 	return nil
 }
 
-func (r Request2) Validate() error {
-	return r.validate()
-}
-
-func (r Request3) validate() error {
+// Validate validates Request3
+func (r Request3) Validate() error {
 	if err := validateMin10(r.Age); err != nil {
 		return err
 	}
@@ -134,32 +102,12 @@ func (r Request3) validate() error {
 	return nil
 }
 
-func (r Request3) Validate() error {
-	return r.validate()
-}
-
-func (r Request4) validate() error {
+// Validate validates Request4
+func (r Request4) Validate() error {
 	if err := r.Age.ValidateMin10(); err != nil {
 		return err
 	}
 	if err := validateMax128(r.Age); err != nil {
-		return err
-	}
-	if r.Some < 3 {
-		return fmt.Errorf("field Some is less than 3 ")
-	}
-	if r.Some > 64 {
-		return fmt.Errorf("field Some is more than 64 ")
-	}
-	return nil
-}
-
-func (r Request4) Validate() error {
-	return r.validate()
-}
-
-func (r Request5) validate() error {
-	if err := r.Age.Validate(); err != nil {
 		return err
 	}
 	if r.Some < 3 {

--- a/examples/overriding/validators.go
+++ b/examples/overriding/validators.go
@@ -118,3 +118,17 @@ func (r Request4) Validate() error {
 	}
 	return nil
 }
+
+// Validate validates Request5
+func (r Request5) Validate() error {
+	if err := r.Age.Validate(); err != nil {
+		return err
+	}
+	if r.Some < 3 {
+		return fmt.Errorf("field Some is less than 3 ")
+	}
+	if r.Some > 64 {
+		return fmt.Errorf("field Some is more than 64 ")
+	}
+	return r.validate()
+}

--- a/examples/simple/validators.go
+++ b/examples/simple/validators.go
@@ -10,20 +10,19 @@ import (
 	"unicode/utf8"
 )
 
-type Validatable interface {
+type validatable interface {
 	Validate() error
 }
 
-func callValidateIfValidatable(i interface{}) error {
-	if v, ok := i.(Validatable); ok {
-		if err := v.Validate(); err != nil {
-			return err
-		}
+func validate(i interface{}) error {
+	if v, ok := i.(validatable); ok {
+		return v.Validate()
 	}
 	return nil
 }
 
-func (r Dog) validate() error {
+// Validate validates Dog
+func (r Dog) Validate() error {
 	if utf8.RuneCountInString(r.Name) < 1 {
 		return fmt.Errorf("field Name is shorter than 1 chars")
 	}
@@ -33,11 +32,8 @@ func (r Dog) validate() error {
 	return nil
 }
 
-func (r Dog) Validate() error {
-	return r.validate()
-}
-
-func (r User) validate() error {
+// Validate validates User
+func (r User) Validate() error {
 	if utf8.RuneCountInString(r.Name) < 3 {
 		return fmt.Errorf("field Name is shorter than 3 chars")
 	}
@@ -67,8 +63,4 @@ func (r User) validate() error {
 		}
 	}
 	return nil
-}
-
-func (r User) Validate() error {
-	return r.validate()
 }

--- a/generator.go
+++ b/generator.go
@@ -103,15 +103,13 @@ func (g generator) genImports(w io.Writer, pkg string, needValidatable bool) {
             {{ end }}        
         )
 	{{if .NeedValidatable}}  
-        type Validatable interface {
+        type validatable interface {
             Validate() error
         }
 
-        func callValidateIfValidatable(i interface{}) error {
-			if v, ok := i.(Validatable); ok {
-				if err := v.Validate(); err != nil {
-					return err
-				}
+        func validate(i interface{}) error {
+			if v, ok := i.(validatable); ok {
+				return v.Validate()
 			}
 			return nil
 		}

--- a/types/type_struct.go
+++ b/types/type_struct.go
@@ -54,7 +54,7 @@ func (t typeStruct) Generate(w io.Writer, cfg GenConfig, name Name) {
 		fmt.Fprintf(w, "    return err\n")
 		fmt.Fprintf(w, "}\n")
 	default:
-		fmt.Fprintf(w, "if err := callValidateIfValidatable(%s); err != nil {\n", name.WithAlias())
+		fmt.Fprintf(w, "if err := validate(%s); err != nil {\n", name.WithAlias())
 		fmt.Fprintf(w, "    return err\n")
 		fmt.Fprintf(w, "}\n")
 	}


### PR DESCRIPTION
Few changes made in this PR:

1. Little bit simplified generated code for validatable interface.
2. Genval generates only exported `Validate() error` func.
3. Some custom validation require only to create unexported `validate` func